### PR TITLE
Query String multi dict

### DIFF
--- a/fastapi_rest_jsonapi/querystring.py
+++ b/fastapi_rest_jsonapi/querystring.py
@@ -81,6 +81,7 @@ class QueryStringManager(object):
         """
         self.request: Request = request
         self.app: FastAPI = request.app
+        # ?? request.query_params.multi_items()
         self.qs: Dict[str, str] = dict(request.query_params)
         self.config: Dict[str, Any] = getattr(self.app, "config", dict())
         self.schema: Type[BaseModel] = schema


### PR DESCRIPTION
Объект `QueryParams`, доступный в `request` по атрибуту `query_params` является MultiDict. Поэтому если делать просто `dict(qs)`, можно потерять часть параметров. 


```python
from starlette.datastructures import QueryParams

qs1 = QueryParams('foo=bar&foo=baz')
print(qs1)
# foo=bar&foo=baz
print(dict(qs1))
# {'foo': 'baz'}
print(qs1.multi_items())
# [('foo', 'bar'), ('foo', 'baz')]
```

Необходимо обсудить и разобраться, возможны ли случаи в JSON:API, когда массив передаётся через QS и нужно ли нам уметь это обрабатывать