### PR TITLE
fix docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,7 +24,8 @@ sphinx:
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
-  - pdf
+  # pdf build fails and stops doc update
+  # - pdf
   - epub
   - htmlzip
 


### PR DESCRIPTION
get rid of pdf docs format because it fails whole doc build 
https://readthedocs.org/projects/fastapi-jsonapi/builds/22062269/ 