### PR TITLE
remove sqlalchemy-stubs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2049,21 +2049,6 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
-name = "sqlalchemy-stubs"
-version = "0.4"
-description = "SQLAlchemy stubs and mypy plugin"
-optional = false
-python-versions = "*"
-files = [
-    {file = "sqlalchemy-stubs-0.4.tar.gz", hash = "sha256:c665d6dd4482ef642f01027fa06c3d5e91befabb219dc71fc2a09e7d7695f7ae"},
-    {file = "sqlalchemy_stubs-0.4-py3-none-any.whl", hash = "sha256:5eec7aa110adf9b957b631799a72fef396b23ff99fe296df726645d01e312aa5"},
-]
-
-[package.dependencies]
-mypy = ">=0.790"
-typing-extensions = ">=3.7.4"
-
-[[package]]
 name = "starlette"
 version = "0.45.3"
 description = "The little ASGI library that shines."
@@ -2402,4 +2387,4 @@ uvicorn = ["uvicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "0182b5ef4cb4ae7df2efe8c076866c3861ffb5eaee6080fd1afc2b9845185f4f"
+content-hash = "fa38c569d3bd529556baa0974b6a5e83155f2b320da138b678f03e7c6428a8f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ black = "^25.1.0"
 mypy = "^1.14.1"
 pre-commit = "^4.1.0"
 ruff = "^0.9.4"
-sqlalchemy-stubs = "^0.4"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = "^7.0.1"


### PR DESCRIPTION
SQLAlchemy 2.0 doesn't need stubs, it's already annotated.