### PR TITLE
fix: compute totalPages from unpaginated count query

### DIFF
--- a/fastapi_jsonapi/data_layers/sqla/orm.py
+++ b/fastapi_jsonapi/data_layers/sqla/orm.py
@@ -425,9 +425,15 @@ class SqlalchemyDataLayer(BaseDataLayer):
 
         objects_count = self.default_collection_count
         if not self.disable_collection_count:
+            count_query = self._base_sql.query(
+                model=self.model,
+                filters=filters,
+                jsonapi_join=relationships_info,
+                stmt=self._query,
+            )
             objects_count = await self._base_sql.count(
                 session=self.session,
-                stmt=query,
+                stmt=count_query,
             )
 
         collection = await self.after_get_collection(collection, qs, view_kwargs)


### PR DESCRIPTION
## Summary

Fixes #103 — `totalPages` always returns `1` regardless of actual row count when using `page[size]` pagination.

**Root cause:** `get_collection()` in `orm.py` builds a query with `LIMIT`/`OFFSET` (pagination), then passes the same query to `count()`. Since `count()` wraps the query as a subquery, the `LIMIT` caps the row count to at most `page_size`, so `totalPages = ceil(page_size / page_size) = 1`.

**Fix:** Build a separate count query with only `filters` and `joins` (no `size`/`number` pagination params). This ensures `count()` returns the total number of matching rows across all pages.

```
Before: GET /items?page[size]=10  →  count=10, totalPages=1  (11 items in DB)
After:  GET /items?page[size]=10  →  count=11, totalPages=2  (correct)
```

## Test plan

- Existing tests are unaffected — they either don't use pagination or don't have more items than page size
- Could not run tests locally due to FastAPI version incompatibility (`field_annotation_is_sequence` removed in latest FastAPI) — please verify in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)